### PR TITLE
Update .env.example to include SESSIONID_DOMAIN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,12 @@ BIND_TO="127.0.0.1:17001"
 # cookie handling.
 DOMAIN="http://127.0.0.1:17001"
 
+# Your domain. In production this is used for secure
+# session handling.
+# Needs to be set for production usage,
+# it's due to cookie handling for local hosts vs domains.
+SESSIONID_DOMAIN="https://www.example.com:17001"
+
 # Your database URL.
 #
 # DATABASE_URL=""


### PR DESCRIPTION
SESSIONID_DOMAIN needs to be set for production usage, it's due to cookie handling for local hosts vs domains.